### PR TITLE
feat(chat): 添加游戏内聊天转发功能

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -14,4 +14,8 @@ motdUrl: play.easecation.net:19132duo
 enableGroupChat: false
 # 群聊消息格式 (可用变量: {nick}, {msg})
 chatFormatGroup: 群:<{nick}> {msg}
+# 游戏消息格式 (可用变量: {name}, {msg})
+chatFormatGame: <{name}> {msg}
+#  游戏消息转发前缀
+chatFormatGamePrefix: '#'
 ...

--- a/src/HuHoBot/Main.php
+++ b/src/HuHoBot/Main.php
@@ -15,9 +15,11 @@ use HuHoBot\events\RunCustomCommandEvent;
 use HuHoBot\events\SendConfigEvent;
 use HuHoBot\events\ShakedEvent;
 use HuHoBot\events\ShutdownEvent;
+use HuHoBot\onChatListener;
 use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
 use pocketmine\event\Listener;
+use pocketmine\event\player\PlayerChatEvent;
 use pocketmine\plugin\PluginBase;
 use pocketmine\snooze\SleeperHandlerEntry;
 use pocketmine\utils\Config;
@@ -46,6 +48,9 @@ class Main extends PluginBase implements Listener {
 			$this->getConfig()->set('serverId', str_replace("-", '', $this->getServer()->getServerUniqueId()->toString()));
 			$this->saveConfig();
 		}
+
+        //注册事件
+        $this->getServer()->getPluginManager()->registerEvents(new onChatListener($this), $this);
 
 		//网络事件注册
 		$this->registerEvent(new ShakedEvent());

--- a/src/HuHoBot/onChatListener.php
+++ b/src/HuHoBot/onChatListener.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace HuHoBot;
+
+use pocketmine\event\Listener;
+use pocketmine\event\player\PlayerChatEvent;
+
+class onChatListener implements Listener{
+
+    public function __construct(private Main $plugin){}
+
+    public function onChat(PlayerChatEvent $event) : void{
+        if((!$event->isCancelled()) && $this->plugin->getConfig()->get('enableGroupChat')){
+            $playerName = $event->getPlayer()->getName();
+            $message = $event->getMessage();
+            $prefix = $this->plugin->getConfig()->get('chatFormatGamePrefix');
+
+            //检测开头前缀
+            if(strpos($message, $prefix) === 0){
+                $chat = $this->plugin->getConfig()->get('chatFormatGame', '<{name}> {msg}');
+                $noPrefixMsg = substr($message, strlen($prefix));
+                $chat = str_replace(['{name}', '{msg}'], [$playerName, $noPrefixMsg], $chat);
+
+                $this->plugin->sendMessage('chat', [
+                    'serverId' => $this->plugin->getConfig()->get('serverId'),
+                    'msg' => $chat,
+                ]);
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
- 在 config.yml 中新增游戏消息格式和转发前缀配置
- 实现 onChatListener 类监听玩家聊天事件
- 当玩家消息以指定前缀开头时，按照配置的格式转发到群聊